### PR TITLE
Support postgres in db extractor

### DIFF
--- a/src/Laravel/DbExtractor.php
+++ b/src/Laravel/DbExtractor.php
@@ -97,6 +97,14 @@ class DbExtractor extends AbstractExtractor
                     . '), 2)) as [_hash]'
                 )
             );
+        } elseif ($this->connection instanceof PostgresConnection) {
+            $query->addSelect(
+                $this->connection->raw(
+                    "MD5(CONCAT_WS('|', "
+                    . collect($this->getUniqueColumns())->implode(',')
+                    . ')) AS "_hash"'
+                )
+            );
         } else {
             throw new \RuntimeException('Currently only MySQL and SqlServer are supported inside the ' . __CLASS__);
         }


### PR DESCRIPTION
Adds similar hash calculation to support Postgres connections. There is only a small syntax difference in how this works for MySQL (backticks for the _hash alias vs double quotes.)